### PR TITLE
Add client_activate timing to debug log

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -296,6 +296,15 @@ Log disconnections with reasons.
 
 Default: 1
 
+==== log_activations ====
+
+Log every time a client has waited for a client to be available, and how much time
+it has spent on that state.
+This happens when there are not any available servers and we have to wait for new
+ones to be created or become available for use.
+
+Default: 0
+
 ==== log_pooler_errors ====
 
 Log error messages pooler sends to clients.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -161,6 +161,9 @@ default_pool_size = 20
 ; log if and why connection was closed
 ;log_disconnections = 1
 
+; log times waiting for client activation
+;log_activations = 1
+
 ; log error messages pooler sends to clients
 ;log_pooler_errors = 1
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -429,6 +429,7 @@ extern int cf_tcp_defer_accept;
 
 extern int cf_log_connections;
 extern int cf_log_disconnections;
+extern int cf_log_activations;
 extern int cf_log_pooler_errors;
 extern int cf_application_name_add_host;
 

--- a/src/main.c
+++ b/src/main.c
@@ -135,6 +135,7 @@ int cf_stats_period;
 
 int cf_log_connections;
 int cf_log_disconnections;
+int cf_log_activations;
 int cf_log_pooler_errors;
 int cf_application_name_add_host;
 
@@ -235,6 +236,7 @@ CF_ABS("stats_users", CF_STR, cf_stats_users, 0, ""),
 CF_ABS("stats_period", CF_INT, cf_stats_period, 0, "60"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
+CF_ABS("log_activations", CF_INT, cf_log_activations, 0, "0"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
 CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
 {NULL}

--- a/src/objects.c
+++ b/src/objects.c
@@ -523,9 +523,10 @@ static void pause_client(PgSocket *client)
 /* wake client from wait */
 void activate_client(PgSocket *client)
 {
-	Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN);
+	usec_t now = get_time_usec();
 
-	slog_debug(client, "activate_client");
+	Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN);
+	slog_debug(client, "activate_client: %ldus", (now - client->query_start));
 	change_client_state(client, CL_ACTIVE);
 	sbuf_continue(&client->sbuf);
 }

--- a/src/objects.c
+++ b/src/objects.c
@@ -526,7 +526,9 @@ void activate_client(PgSocket *client)
 	usec_t now = get_time_usec();
 
 	Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN);
-	slog_debug(client, "activate_client: %ldus", (now - client->query_start));
+  	if (cf_log_activations)
+    		slog_info(client, "activate_client: %ldus", (now - client->query_start));
+	slog_debug(client, "activate_client");
 	change_client_state(client, CL_ACTIVE);
 	sbuf_continue(&client->sbuf);
 }

--- a/test/ctest6000.ini
+++ b/test/ctest6000.ini
@@ -31,6 +31,7 @@ default_pool_size = 20
 
 log_connections = 0
 log_disconnections = 0
+log_activations = 0
 log_pooler_errors = 0
 
 server_lifetime = 30

--- a/test/ctest7000.ini
+++ b/test/ctest7000.ini
@@ -31,6 +31,7 @@ default_pool_size = 20
 
 log_connections = 0
 log_disconnections = 0
+log_activations = 0
 log_pooler_errors = 0
 
 server_lifetime = 30


### PR DESCRIPTION
This will output on the DEBUG output (when `-v` for verbose is enabled) the time in useconds that has passed since the query has started until the client has been activated.

client_activate happens only when the query has been paused.
This happens when there are not any available servers on the pool, while we wait for a connection to be available (either from a new connection opening being triggered, or an already established connection from the pool being freed).

Example log output:

```
$ sudo tail -f /var/log/postgresql/pgbouncer.log |grep activate_client
2015-12-11 16:42:39.764 3228 DEBUG C-0x221b530: cartodb_dev_user_c32bad67-5516-48be-a4c4-245335560385_db/development_cartodb_user_c32bad67-5516-48be-a4c4-245335560385@127.0.0.1:56214 activate_client 0us
2015-12-11 16:42:53.906 3228 DEBUG C-0x221a720: cartodb_dev_user_c32bad67-5516-48be-a4c4-245335560385_db/development_cartodb_user_c32bad67-5516-48be-a4c4-245335560385@127.0.0.1:56244 activate_client 292us
2015-12-11 16:43:19.207 3228 DEBUG C-0x221bda0: cartodb_dev_user_c32bad67-5516-48be-a4c4-245335560385_db/development_cartodb_user_c32bad67-5516-48be-a4c4-245335560385@127.0.0.1:57325 activate_client 1231us
2015-12-11 16:43:23.557 3228 DEBUG C-0x221bda0: cartodb_dev_user_c32bad67-5516-48be-a4c4-245335560385_db/development_cartodb_user_c32bad67-5516-48be-a4c4-245335560385@127.0.0.1:57325 activate_client 4446us
```

cc @rochoa @luisbosque
